### PR TITLE
Add a way to set the Kind from Embeddable #164

### DIFF
--- a/src/main/java/com/jmethods/catatumbo/OverrideKind.java
+++ b/src/main/java/com/jmethods/catatumbo/OverrideKind.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Sai Pullabhotla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jmethods.catatumbo;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A class annotated with <code>OverrideKind</code> specifies a new kind
+ * for the enclosing {@link Entity} when using within an {@link Embedded} field.
+ * Only {@link Embeddable} classes can be annotated with this annotation.
+ *
+ * @author Aurelien Thieriot
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OverrideKind {
+
+  /**
+   * The new kind value
+   * 
+   * @return the kind
+   */
+  String kind();
+}

--- a/src/main/java/com/jmethods/catatumbo/impl/EntityIntrospector.java
+++ b/src/main/java/com/jmethods/catatumbo/impl/EntityIntrospector.java
@@ -31,12 +31,14 @@ import java.util.List;
 
 import com.jmethods.catatumbo.CreatedTimestamp;
 import com.jmethods.catatumbo.DatastoreKey;
+import com.jmethods.catatumbo.Embeddable;
 import com.jmethods.catatumbo.Embedded;
 import com.jmethods.catatumbo.Entity;
 import com.jmethods.catatumbo.EntityManagerException;
 import com.jmethods.catatumbo.Identifier;
 import com.jmethods.catatumbo.Key;
 import com.jmethods.catatumbo.MappedSuperClass;
+import com.jmethods.catatumbo.OverrideKind;
 import com.jmethods.catatumbo.ParentKey;
 import com.jmethods.catatumbo.ProjectedEntity;
 import com.jmethods.catatumbo.Property;
@@ -296,6 +298,7 @@ public class EntityIntrospector {
         processParentKeyField(field, fieldType);
       } else if (field.isAnnotationPresent(Embedded.class)) {
         processEmbeddedField(field, fieldType);
+        processOverrideKind(field, fieldType);
       } else {
         processField(field, fieldType);
       }
@@ -490,6 +493,32 @@ public class EntityIntrospector {
     EmbeddedMetadata embeddedMetadata = EmbeddedIntrospector.introspect(embeddedField,
         entityMetadata);
     entityMetadata.putEmbeddedMetadata(embeddedMetadata);
+  }
+
+  /**
+   * Process an OverrideKind annotation on an embedded field and
+   * update the current entity metadata if needs be
+   *
+   * @param field
+   *          the embedded field
+   * @param type
+   *          the field type
+   */
+  private void processOverrideKind(Field field, Class<?> type) {
+    OverrideKind overrideKind = type.getAnnotation(OverrideKind.class);
+    Embeddable embeddable = type.getAnnotation(Embeddable.class);
+
+    if (overrideKind != null) {
+      if (embeddable == null) {
+        String message = String.format("A class annotated with %s must also be annotated with %s",
+                                       OverrideKind.class.getName(),
+                                       Embeddable.class.getName()
+        );
+        throw new EntityManagerException(message);
+      }
+
+      entityMetadata.setKind(overrideKind.kind());
+    }
   }
 
   /**

--- a/src/main/java/com/jmethods/catatumbo/impl/EntityMetadata.java
+++ b/src/main/java/com/jmethods/catatumbo/impl/EntityMetadata.java
@@ -172,6 +172,16 @@ public class EntityMetadata extends MetadataBase {
   }
 
   /**
+   * Sets the metadata Kind.
+   *
+   * @param kind
+   *        entity kind parameter
+   */
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  /**
    * Returns the metadata of the identifier.
    *
    * @return the metadata of the identifier.

--- a/src/test/java/com/jmethods/catatumbo/entities/WrappedZipCode.java
+++ b/src/test/java/com/jmethods/catatumbo/entities/WrappedZipCode.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 Sai Pullabhotla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jmethods.catatumbo.entities;
+
+import com.jmethods.catatumbo.Embeddable;
+import com.jmethods.catatumbo.Embedded;
+import com.jmethods.catatumbo.OverrideKind;
+import com.jmethods.catatumbo.Property;
+
+import java.util.Objects;
+
+/**
+ * @author Aurelien Thieriot
+ *
+ */
+@Embeddable
+@OverrideKind(kind = "wrapped")
+public class WrappedZipCode {
+
+  @Property(name = "zip")
+  private String fiveDigits;
+
+  @Property(name = "zipx", indexed = false, optional = true)
+  private String fourDigits;
+
+  @Embedded(name = "useless", indexed = true)
+  private AnotherEmbeddable anotherEmbeddable = new AnotherEmbeddable();
+
+  /**
+   *
+   */
+  public WrappedZipCode() {
+  	// TODO Auto-generated constructor stub
+  }
+
+  /**
+   * @return the fiveDigits
+   */
+  public String getFiveDigits() {
+    return fiveDigits;
+  }
+
+  /**
+   * @param fiveDigits
+   *            the fiveDigits to set
+   */
+  public void setFiveDigits(String fiveDigits) {
+    this.fiveDigits = fiveDigits;
+  }
+
+  /**
+   * @return the fourDigits
+   */
+  public String getFourDigits() {
+    return fourDigits;
+  }
+
+  /**
+   * @param fourDigits
+   *          the fourDigits to set
+   */
+  public void setFourDigits(String fourDigits) {
+    this.fourDigits = fourDigits;
+  }
+
+  @Override
+  public String toString() {
+    return fiveDigits + "-" + fourDigits;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof ZipCode)) {
+      return false;
+    }
+    WrappedZipCode that = (WrappedZipCode) obj;
+    return Objects.equals(this.fiveDigits, that.fiveDigits) && Objects.equals(this.fourDigits, that.fourDigits)
+                    && Objects.equals(this.anotherEmbeddable, that.anotherEmbeddable);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fiveDigits, fourDigits, anotherEmbeddable);
+  }
+
+  /**
+   * @return the anotherEmbeddable
+   */
+  public AnotherEmbeddable getAnotherEmbeddable() {
+    return anotherEmbeddable;
+  }
+
+  /**
+   * @param anotherEmbeddable
+   *          the anotherEmbeddable to set
+   */
+  public void setAnotherEmbeddable(AnotherEmbeddable anotherEmbeddable) {
+    this.anotherEmbeddable = anotherEmbeddable;
+  }
+
+}

--- a/src/test/java/com/jmethods/catatumbo/entities/ZipCodeWrapper.java
+++ b/src/test/java/com/jmethods/catatumbo/entities/ZipCodeWrapper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Sai Pullabhotla.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.jmethods.catatumbo.entities;
+
+import com.jmethods.catatumbo.Embedded;
+import com.jmethods.catatumbo.Entity;
+import com.jmethods.catatumbo.Identifier;
+
+/**
+ * @author Aurelien Thieriot
+ *
+ */
+@Entity(kind = "generic")
+public class ZipCodeWrapper {
+
+  @Identifier
+  private long id;
+
+  @Embedded
+  private WrappedZipCode wrappedZipCode;
+
+  public ZipCodeWrapper() {
+
+  }
+
+  public ZipCodeWrapper(long id, WrappedZipCode wrappedZipCode) {
+    this.id = id;
+    this.wrappedZipCode = wrappedZipCode;
+  }
+
+  /**
+   * @return the id
+   */
+  public long getId() {
+    return id;
+  }
+
+  /**
+   * @param id
+   *            the id to set
+   */
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public WrappedZipCode getWrappedZipCode() {
+    return wrappedZipCode;
+  }
+
+  public void setWrappedZipCode(WrappedZipCode wrappedZipCode) {
+    this.wrappedZipCode = wrappedZipCode;
+  }
+}

--- a/src/test/java/com/jmethods/catatumbo/impl/EntityIntrospectorTest.java
+++ b/src/test/java/com/jmethods/catatumbo/impl/EntityIntrospectorTest.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import com.jmethods.catatumbo.entities.Address;
 import com.jmethods.catatumbo.entities.GenericEntity;
 import com.jmethods.catatumbo.entities.GenericParameterizedType;
+import com.jmethods.catatumbo.entities.ZipCodeWrapper;
 import org.junit.Test;
 
 import com.jmethods.catatumbo.EntityManagerException;
@@ -186,6 +187,12 @@ public class EntityIntrospectorTest {
     EntityMetadata entityMetadata = EntityIntrospector.introspect(TaskName.class);
     assertEquals("Task", entityMetadata.getKind());
     assertEquals(1, entityMetadata.getPropertyMetadataCollection().size());
+  }
+
+  @Test
+  public void testIntrospect_ZipCodeWrapper() {
+    EntityMetadata entityMetadata = EntityIntrospector.introspect(ZipCodeWrapper.class);
+    assertEquals("wrapped", entityMetadata.getKind());
   }
 
   @Test(expected = EntityManagerException.class)


### PR DESCRIPTION
We have this use case where we use a Wrapper that embed a generic
object in one of its field.

```
@Entity
public class Wrapper {

   @Embedded
   private Interface content;

   ...
}
```

The content can be of any subtype of Interface (some of them will be
outside of our control) and the ```Kind``` value can change with any of
these subtypes.

This Pull Request allow a developer to provide an ```Embeddable``` class
that will override the ```Kind``` of the enclosing ```Entity```.

It will look like this:

```
@Embeddable
@OverrideKind(kind = "mycontent")
public class MyContent implement Interface {

   ...
}
```