### PR TITLE
Increased the version of google-cloud-datastore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
-      <version>1.5.1</version>
+      <version>1.14.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
The version has been moved from 1.5.1 to 1.14.0 to
fix the 5 second latency issue we have been seeing
when calling Datastore service.